### PR TITLE
Add support for py35, pypy26

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# See GITATTRIBUTES(5) (``man gitattributes``).
+# - ``diff=<language>`` declares that diff hunk headers and git-diff word diffs
+#   (for ``git diff --word-diff`` and ``git diff --color-words``) should be
+#   specially computed for the language grammar.  This makes git-diff more
+#   powerful and useful.
+*.py   text eol=lf   diff=python
+*.txt  text eol=lf
+*.rst  text eol=lf
+*.in   text eol=lf
+*.ini  text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Backup files
+*.~
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
 
 # C extensions
@@ -14,20 +19,49 @@ bin
 var
 sdist
 develop-eggs
+.Python
+env/
+downloads/
 .installed.cfg
 lib
 lib64
+MANIFEST
+.eggs/
+.pyenv/
+.venv/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
 # Installer logs
 pip-log.txt
+pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+htmlcov/
 .coverage
 .tox
+.cache
 nosetests.xml
+coverage.xml
+.coverage.*
+*,cover
 
 # Translations
 *.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
 
 # Mr Developer
 .mr.developer.cfg
@@ -35,8 +69,11 @@ nosetests.xml
 .pydevproject
 
 # IntelliJ
-.idea/tasks.xml
-.idea/workspace.xml
+.idea/
+*.iml
 
 # Mac noise
 .DS_Store
+
+# Misc
+tokens.pk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,39 @@
+sudo: false
 language: python
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=pypy
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=pep8
-  - TOX_ENV=pylint
-  - TOX_ENV=coverage
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+before_cache:
+  - rm -r -f $HOME/.cache/pip/log
+
+matrix:
+  include:
+    - python: 2.6
+      env: TOX_ENV=py26
+    - python: 2.7
+      env: TOX_ENV=py27
+    - python: pypy
+      env: TOX_ENV=pypy
+    - python: 3.3
+      env: TOX_ENV=py33
+    - python: 3.4
+      env: TOX_ENV=py34
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 2.7
+      env: TOX_ENV=pep8
+    - python: 2.7
+      env: TOX_ENV=pylint
+    - python: 2.7
+      env: TOX_ENV=coverage
+
 # commands to install dependencies
 install:
-  - pip install tox --use-mirrors
+  - ./.travis/install.sh
 # commands to run
 script:
-  - tox -e $TOX_ENV
+  - ./.travis/run.sh
 after_success:
   - if [ "-x$TOX_ENV" = "xcoverage" ]; then coveralls; fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Originally from
+# <https://github.com/pyca/cryptography/blob/d93aa99636b06d5d403130425098b2f0cc1b516e/.travis/install.sh>.
+
+set -e
+set -x
+set -o pipefail
+
+git clean -f -d -X
+rm -r -f $PWD/.pyenv  # Apparently `git-clean` won't remove other repositories.
+
+export PYENV_ROOT="$PWD/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew install pyenv
+    brew outdated pyenv || brew upgrade pyenv
+
+    if which -s pyenv; then
+        eval "$(pyenv init -)"
+    fi
+
+    case "${TOX_ENV}" in
+        py26)
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py --user
+            ;;
+        py27)
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py --user
+            ;;
+        py33)
+            pyenv install 3.3.6
+            pyenv global 3.3.6
+            ;;
+        py34)
+            pyenv install 3.4.2
+            pyenv global 3.4.2
+            ;;
+        py35)
+            pyenv install 3.5.0
+            pyenv global 3.5.0
+            ;;
+        pypy)
+            pyenv install pypy-2.6.0
+            pyenv global pypy-2.6.0
+            ;;
+    esac
+    pyenv rehash
+    python -m pip install -U --user virtualenv
+else
+    # temporary pyenv installation to get pypy-2.6 before container infra upgrade
+    if [[ "${TOX_ENV}" == "pypy" ]]; then
+        git clone https://github.com/yyuu/pyenv.git $PWD/.pyenv
+        eval "$(pyenv init -)"
+        pyenv install pypy-2.6.0
+        pyenv global pypy-2.6.0
+    fi
+    pip install -U virtualenv
+fi
+
+python -m virtualenv $PWD/.venv
+source $PWD/.venv/bin/activate
+pip install -U tox

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Originally from
+# <https://github.com/pyca/cryptography/blob/d93aa99636b06d5d403130425098b2f0cc1b516e/.travis/install.sh>.
+
+set -e
+set -x
+set -o pipefail
+
+export PYENV_ROOT="$PWD/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    eval "$(pyenv init -)"
+else
+    if [[ "${TOX_ENV}" == "pypy" ]]; then
+        eval "$(pyenv init -)"
+        pyenv global pypy-2.6.0
+    fi
+fi
+source $PWD/.venv/bin/activate
+tox -e $TOX_ENV -- $TOX_FLAGS

--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,9 @@ Run all tests using:
 
 The tox tests include code style checks via pep8 and pylint.
 
+The tox tests are configured to run on Python 2.6, 2.7, 3.3, 3.4, 3.5, and
+PyPy 2.6.
+
 
 Copyright and License
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     pypy,
     py33,
     py34,
+    py35,
     pylint,
     coverage
 


### PR DESCRIPTION
Add support and testing for:
- CPython 3.5
- PyPy 2.6.0.

PyPy 2.6 isn't available by default on Travis CI. Only PyPy 2.5 is.

Borrow some of the Travis CI setup from the PyCA's cryptography project [1], which installs pyenv [2] in order to bootstrap an installation for PyPy 2.6.

[1] <https://github.com/pyca/cryptography/tree/master/.travis>
[2] <https://github.com/yyuu/pyenv>